### PR TITLE
feat: insanely speed up apps filters

### DIFF
--- a/src/app/[locale]/(dashboard)/dashboard/_components/AppsContent.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/_components/AppsContent.tsx
@@ -121,25 +121,13 @@ export function AppsContent({ newLayout, currentCategory }: AppsContentProps) {
       const { network, category, tags, ...params } = Object.fromEntries(
         searchParams.entries()
       );
-      const { category: newCategory, ...newParamsToUpdate } = newParams;
-      router.replace(
-        {
-          pathname: newLayout ? `/new/dashboard/[category]` : "/dashboard",
-          params: {
-            category: newCategory || "",
-          },
-          query: {
-            ...params,
-            ...newParamsToUpdate,
-            ...(newLayout ? {} : { category: newCategory }),
-          },
-        },
-        {
-          scroll: false,
-        }
-      );
+      const queryParams = new URLSearchParams({
+        ...params,
+        ...newParams,
+      });
+      window.history.pushState("", "", `/dashboard?${queryParams}`);
     },
-    [newLayout, searchParams, router]
+    [searchParams]
   );
   const updateFilters = useCallback(
     (newFilters: Partial<InkAppFilters>) => {
@@ -151,7 +139,7 @@ export function AppsContent({ newLayout, currentCategory }: AppsContentProps) {
             ? { network: mergedFilters.network }
             : {}),
           ...(mergedFilters.tags && mergedFilters.tags.length > 0
-            ? { tags: mergedFilters.tags[0] }
+            ? { tags: mergedFilters.tags.join(",") }
             : {}),
           ...(mergedFilters.categories && mergedFilters.categories.length > 0
             ? { category: mergedFilters.categories[0] }


### PR DESCRIPTION
Pure insanity.

I don't know why, each `router.replace` takes something like 500-1000ms.

Just replacing with a very, very simple `window.history` makes it instant and works perfectly

Something I noticed while working on the new layout