### PR TITLE
Fix Typo in MorpheusMeshMaterial Warning Comment

### DIFF
--- a/src/components/MainBackground/Morpheus.tsx
+++ b/src/components/MainBackground/Morpheus.tsx
@@ -74,7 +74,7 @@ export class MorpheusMeshMaterial extends THREE.MeshPhysicalMaterial {
     }
   }
 
-  // Carefull this happens everyframe
+  // Careful this happens everyframe
   incrementTime(deltaTime: number) {
     if (this.userData.shader) {
       this.userData.shader.uniforms.uTime.value += deltaTime;


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the warning comment within the MorpheusMeshMaterial class, changing "Carefull" to "Careful" for improved clarity and professionalism. No functional code changes were made.