### PR TITLE
fix: prevent keyboard handlers stack mutation during iteration

### DIFF
--- a/src/hooks/useGlobalKey.ts
+++ b/src/hooks/useGlobalKey.ts
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
 import { sendGTMEvent } from "@next/third-parties/google";
+import { useEffect } from "react";
 
 type KeyboardKey = KeyboardEvent["key"];
 
@@ -28,7 +28,7 @@ export function useGlobalKeyCallback() {
       if (!(lowerKey in allHandlersStacks)) return;
       if (shouldHandleAsNativeEvent(event)) return;
       const handlersStack = allHandlersStacks[lowerKey];
-      for (let handler of handlersStack.reverse()) {
+      for (let handler of [...handlersStack].reverse()) {
         if (handler()) {
           event.preventDefault();
           event.stopPropagation();
@@ -63,7 +63,9 @@ export const useCallbackOnKey = ({
     return () => {
       if (!isDisabled) {
         const index = allHandlersStacks[lowerKey].indexOf(handler);
-        allHandlersStacks[lowerKey].splice(index, 1);
+        if (index > -1) {
+          allHandlersStacks[lowerKey].splice(index, 1);
+        }
       }
     };
   }, [key, handler, isDisabled]);


### PR DESCRIPTION
##  Bug Fix

### Problem
The keyboard handlers stack gets permanently mutated during iteration, causing unpredictable behavior on subsequent key presses.

### Root Cause
```javascript
for (let handler of handlersStack.reverse()) {
 //                              ^^^^^^^^^ Mutates original array
 ```
The .reverse() method modifies the array in-place, so after the first keydown event, all handlers are permanently stored in reverse order, breaking the expected execution sequence.

### Solution
Use array spread to create a copy before reversing:
```
javascript
for (let handler of [...handlersStack].reverse()) {
  //                  ^^^ Creates copy, preserves original order
  ```

Additionally, fix handler cleanup to prevent removing wrong handlers:
```
javascript 
const index = allHandlersStacks[lowerKey].indexOf(handler);
if (index > -1) {  // Check handler exists before removal
  allHandlersStacks[lowerKey].splice(index, 1);
}
```
  
### Impact
- Fixes inconsistent keyboard shortcut behavior after first use
- Ensures handlers execute in correct LIFO order on every key press
- Prevents accidental removal of wrong handlers during cleanup
- Maintains backwards compatibility with existing functionality

### Files Changed
**hooks/useGlobalKey.ts** - Fixed array mutation and cleanup logic
