### PR TITLE
fix: prevent swap modal closing on network switch

### DIFF
--- a/src/components/RelayKitUI/RelayKitUI.tsx
+++ b/src/components/RelayKitUI/RelayKitUI.tsx
@@ -4,7 +4,7 @@ import { InkIcon } from "@inkonchain/ink-kit";
 import { useConnectModal } from "@rainbow-me/rainbowkit";
 import { SwapWidget } from "@reservoir0x/relay-kit-ui";
 import { adaptViemWallet } from "@reservoir0x/relay-sdk";
-import { useWalletClient } from "wagmi";
+import { useAccount, useWalletClient } from "wagmi";
 
 import { RelayLogo } from "@/components/icons/RelayLogo";
 
@@ -14,6 +14,7 @@ import "./RelayKitUI.css";
 export const RelayKitUI: React.FC = () => {
   const { openConnectModal } = useConnectModal();
   const { data: walletClient } = useWalletClient();
+  const { address } = useAccount();
 
   const [fromToken, setFromToken] = useState({
     chainId: 1,
@@ -48,7 +49,7 @@ export const RelayKitUI: React.FC = () => {
           )}
         </div>
         <SwapWidget
-          key={walletClient?.account.address}
+          key={address}
           wallet={walletClient ? adaptViemWallet(walletClient) : undefined}
           fromToken={fromToken}
           setFromToken={(token) => token && setFromToken(token)}

--- a/src/contexts/RelayProvider.tsx
+++ b/src/contexts/RelayProvider.tsx
@@ -5,7 +5,6 @@ import { useRelayChains } from "@reservoir0x/relay-kit-hooks";
 import { RelayKitProvider } from "@reservoir0x/relay-kit-ui";
 import { MAINNET_RELAY_API } from "@reservoir0x/relay-sdk";
 
-import { clientEnv } from "@/env-client";
 import { useCurrentInkAppName } from "@/hooks/useCurrentInkAppName";
 import { theme } from "@/util/relay-kit-theme";
 


### PR DESCRIPTION
- Fixed `SwapWidget` key to use stable `address` from `useAccount`
- Prevents modal closure during network switches
- Widget now properly resets on wallet disconnect/connect
