### PR TITLE
fix(security): patch CVE-2026-23869 RSC denial of service

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,9 @@
 ## Reporting a Vulnerability
 
 For any security-related issues, please refer to our [Responsible Disclosure policy](https://www.kraken.com/features/security/bug-bounty). It's crucial that these matters are handled sensitively to protect all users.
+
+## Disclosed Advisories
+
+| Date       | CVE              | Severity | Component                          | Resolution                                                                 |
+| ---------- | ---------------- | -------- | ---------------------------------- | -------------------------------------------------------------------------- |
+| 2026-05-08 | CVE-2026-23869   | High 7.5 | React Server Components (App Router server actions) | Bumped `next` 15.4.11 → 15.5.15 and `react`/`react-dom` 19.0.4 → 19.0.5. See [Next.js advisory GHSA-q4gf-8mx6-v5v3](https://github.com/vercel/next.js/security/advisories/GHSA-q4gf-8mx6-v5v3) and [React advisory GHSA-479c-33wc-g2pg](https://github.com/facebook/react/security/advisories/GHSA-479c-33wc-g2pg). |

--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
     "leva": "0.9.35",
     "lottie-react": "2.4.0",
     "maath": "0.10.7",
-    "next": "15.4.11",
+    "next": "15.5.15",
     "next-intl": "3.25.1",
     "next-themes": "0.3.0",
     "postprocessing": "6.35.5",
     "prettier": "3.3.3",
-    "react": "19.0.4",
+    "react": "19.0.5",
     "react-confetti": "6.1.0",
-    "react-dom": "19.0.4",
+    "react-dom": "19.0.5",
     "react-focus-lock": "2.13.2",
     "react-hook-form": "7.54.1",
     "react-toastify": "10.0.5",
@@ -91,8 +91,8 @@
     "overrides": {
       "@types/react": "19.0.7",
       "@types/react-dom": "19.0.3",
-      "react": "19.0.4",
-      "react-dom": "19.0.4"
+      "react": "19.0.5",
+      "react-dom": "19.0.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 overrides:
   '@types/react': 19.0.7
   '@types/react-dom': 19.0.3
-  react: 19.0.4
-  react-dom: 19.0.4
+  react: 19.0.5
+  react-dom: 19.0.5
 
 importers:
 
@@ -16,13 +16,13 @@ importers:
     dependencies:
       '@hookform/resolvers':
         specifier: 3.9.1
-        version: 3.9.1(react-hook-form@7.54.1(react@19.0.4))
+        version: 3.9.1(react-hook-form@7.54.1(react@19.0.5))
       '@inkonchain/ink-kit':
         specifier: 0.9.1-beta.19
-        version: 0.9.1-beta.19(@tanstack/react-query@5.60.6(react@19.0.4))(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(tailwindcss@4.0.8)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
+        version: 0.9.1-beta.19(@tanstack/react-query@5.60.6(react@19.0.5))(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(tailwindcss@4.0.8)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
       '@next/third-parties':
         specifier: 15.1.6
-        version: 15.1.6(next@15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6))(react@19.0.4)
+        version: 15.1.6(next@15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6))(react@19.0.5)
       '@octokit/auth-app':
         specifier: 7.1.3
         version: 7.1.3
@@ -31,25 +31,25 @@ importers:
         version: 21.0.2
       '@radix-ui/react-tooltip':
         specifier: 1.1.8
-        version: 1.1.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+        version: 1.1.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       '@rainbow-me/rainbowkit':
         specifier: 2.2.8
-        version: 2.2.8(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(typescript@5.7.3)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
+        version: 2.2.8(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(typescript@5.7.3)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
       '@react-three/drei':
         specifier: 9.107.2
-        version: 9.107.2(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0))(@types/react@19.0.7)(@types/three@0.170.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0)
+        version: 9.107.2(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0))(@types/react@19.0.7)(@types/three@0.170.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0)
       '@react-three/fiber':
         specifier: 9.0.0-rc.0
-        version: 9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0)
+        version: 9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0)
       '@react-three/postprocessing':
         specifier: 2.16.2
-        version: 2.16.2(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0))(@types/three@0.170.0)(react@19.0.4)(three@0.165.0)
+        version: 2.16.2(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0))(@types/three@0.170.0)(react@19.0.5)(three@0.165.0)
       '@reservoir0x/relay-kit-hooks':
         specifier: 1.12.0
-        version: 1.12.0(@tanstack/react-query@5.60.6(react@19.0.4))(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
+        version: 1.12.0(@tanstack/react-query@5.60.6(react@19.0.5))(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
       '@reservoir0x/relay-kit-ui':
         specifier: 2.17.2
-        version: 2.17.2(@pandacss/dev@0.51.1(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.7.3))(@radix-ui/colors@3.0.0)(@tanstack/react-query@5.60.6(react@19.0.4))(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
+        version: 2.17.2(@pandacss/dev@0.51.1(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.7.3))(@radix-ui/colors@3.0.0)(@tanstack/react-query@5.60.6(react@19.0.5))(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
       '@reservoir0x/relay-sdk':
         specifier: 2.4.0
         version: 2.4.0(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
@@ -58,7 +58,7 @@ importers:
         version: 1.70.0
       '@sentry/nextjs':
         specifier: 8.54.0
-        version: 8.54.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6))(react@19.0.4)(webpack@5.97.1)
+        version: 8.54.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6))(react@19.0.5)(webpack@5.97.1)
       '@slack/web-api':
         specifier: 7.8.0
         version: 7.8.0
@@ -67,7 +67,7 @@ importers:
         version: 0.12.0(typescript@5.7.3)(zod@3.24.1)
       '@tanstack/react-query':
         specifier: 5.60.6
-        version: 5.60.6(react@19.0.4)
+        version: 5.60.6(react@19.0.5)
       '@types/react':
         specifier: 19.0.7
         version: 19.0.7
@@ -79,7 +79,7 @@ importers:
         version: 0.170.0
       '@walletconnect/ethereum-provider':
         specifier: 2.21.4
-        version: 2.21.4(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+        version: 2.21.4(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -91,7 +91,7 @@ importers:
         version: 6.13.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       framer-motion:
         specifier: 12.0.0-alpha.1
-        version: 12.0.0-alpha.1(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+        version: 12.0.0-alpha.1(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       isomorphic-dompurify:
         specifier: 2.21.0
         version: 2.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -100,22 +100,22 @@ importers:
         version: 5.9.6
       leva:
         specifier: 0.9.35
-        version: 0.9.35(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+        version: 0.9.35(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       lottie-react:
         specifier: 2.4.0
-        version: 2.4.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+        version: 2.4.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       maath:
         specifier: 0.10.7
         version: 0.10.7(@types/three@0.170.0)(three@0.165.0)
       next:
-        specifier: 15.4.11
-        version: 15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6)
+        specifier: 15.5.15
+        version: 15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6)
       next-intl:
         specifier: 3.25.1
-        version: 3.25.1(next@15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6))(react@19.0.4)
+        version: 3.25.1(next@15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6))(react@19.0.5)
       next-themes:
         specifier: 0.3.0
-        version: 0.3.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+        version: 0.3.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       postprocessing:
         specifier: 6.35.5
         version: 6.35.5(three@0.165.0)
@@ -123,23 +123,23 @@ importers:
         specifier: 3.3.3
         version: 3.3.3
       react:
-        specifier: 19.0.4
-        version: 19.0.4
+        specifier: 19.0.5
+        version: 19.0.5
       react-confetti:
         specifier: 6.1.0
-        version: 6.1.0(react@19.0.4)
+        version: 6.1.0(react@19.0.5)
       react-dom:
-        specifier: 19.0.4
-        version: 19.0.4(react@19.0.4)
+        specifier: 19.0.5
+        version: 19.0.5(react@19.0.5)
       react-focus-lock:
         specifier: 2.13.2
-        version: 2.13.2(@types/react@19.0.7)(react@19.0.4)
+        version: 2.13.2(@types/react@19.0.7)(react@19.0.5)
       react-hook-form:
         specifier: 7.54.1
-        version: 7.54.1(react@19.0.4)
+        version: 7.54.1(react@19.0.5)
       react-toastify:
         specifier: 10.0.5
-        version: 10.0.5(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+        version: 10.0.5(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       sass:
         specifier: 1.77.6
         version: 1.77.6
@@ -154,7 +154,7 @@ importers:
         version: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       wagmi:
         specifier: 2.17.5
-        version: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
+        version: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
       zod:
         specifier: 3.24.1
         version: 3.24.1
@@ -576,14 +576,14 @@ packages:
   '@floating-ui/react-dom@2.1.6':
     resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   '@floating-ui/react@0.26.28':
     resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
@@ -620,7 +620,7 @@ packages:
     deprecated: v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.
     peerDependencies:
       '@fortawesome/fontawesome-svg-core': ~1 || ~6 || ~7
-      react: 19.0.4
+      react: 19.0.5
 
   '@gemini-wallet/core@0.2.0':
     resolution: {integrity: sha512-vv9aozWnKrrPWQ3vIFcWk7yta4hQW1Ie0fsNNPeXnjAxkbXr2hqMagEptLuMxpEP2W3mnRu05VDNKzcvAuuZDw==}
@@ -631,8 +631,8 @@ packages:
     resolution: {integrity: sha512-RzCEg+LXsuI7mHiSomsu/gBJSjpupm6A1qIZ5sWjd7JhARNlMiSA4kKfJpCKwU9tE+zMRterhhrP74PvfJrpXQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   '@hookform/resolvers@3.9.1':
     resolution: {integrity: sha512-ud2HqmGBM0P0IABqoskKWI6PEf6ZDDBZkFqe2Vnl+mTHCEHzr3ISjjZyCwTjC/qpL25JC9aIDkloQejvMeq0ug==}
@@ -903,8 +903,8 @@ packages:
     deprecated: See README for modern alternatives including shadcn/ui, RainbowKit, and ConnectKit
     peerDependencies:
       '@tanstack/react-query': ^5
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
       tailwindcss: ^3 || ^4
       viem: ^2
       wagmi: ^2
@@ -986,9 +986,11 @@ packages:
 
   '@metamask/sdk-analytics@0.0.5':
     resolution: {integrity: sha512-fDah+keS1RjSUlC8GmYXvx6Y26s3Ax1U9hGpWb6GSY5SAdmTSIqp2CvYy6yW0WgLhnYhW+6xERuD0eVqV63QIQ==}
+    deprecated: No longer maintained, superseded by @metamask/connect-analytics
 
   '@metamask/sdk-communication-layer@0.33.1':
     resolution: {integrity: sha512-0bI9hkysxcfbZ/lk0T2+aKVo1j0ynQVTuB3sJ5ssPWlz+Z3VwveCkP1O7EVu1tsVVCb0YV5WxK9zmURu2FIiaA==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
     peerDependencies:
       cross-fetch: ^4.0.0
       eciesjs: '*'
@@ -998,9 +1000,11 @@ packages:
 
   '@metamask/sdk-install-modal-web@0.32.1':
     resolution: {integrity: sha512-MGmAo6qSjf1tuYXhCu2EZLftq+DSt5Z7fsIKr2P+lDgdTPWgLfZB1tJKzNcwKKOdf6q9Qmmxn7lJuI/gq5LrKw==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/sdk@0.33.1':
     resolution: {integrity: sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==}
+    deprecated: No longer maintained, superseded by https://docs.metamask.io/metamask-connect
 
   '@metamask/superstruct@3.2.1':
     resolution: {integrity: sha512-fLgJnDOXFmuVlB38rUN5SmU7hAFQcCjrg3Vrxz67KTY7YHFnSNEKvX4avmEBdOI0yTCxZjwMCFEqsC8k2+Wd3g==}
@@ -1031,56 +1035,56 @@ packages:
     resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
     engines: {node: '>= 18'}
 
-  '@next/env@15.4.11':
-    resolution: {integrity: sha512-mIYp/091eYfPFezKX7ZPTWqrmSXq+ih6+LcUyKvLmeLQGhlPtot33kuEOd4U+xAA7sFfj21+OtCpIZx0g5SpvQ==}
+  '@next/env@15.5.15':
+    resolution: {integrity: sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==}
 
   '@next/eslint-plugin-next@15.0.3':
     resolution: {integrity: sha512-3Ln/nHq2V+v8uIaxCR6YfYo7ceRgZNXfTd3yW1ukTaFbO+/I8jNakrjYWODvG9BuR2v5kgVtH/C8r0i11quOgw==}
 
-  '@next/swc-darwin-arm64@15.4.8':
-    resolution: {integrity: sha512-Pf6zXp7yyQEn7sqMxur6+kYcywx5up1J849psyET7/8pG2gQTVMjU3NzgIt8SeEP5to3If/SaWmaA6H6ysBr1A==}
+  '@next/swc-darwin-arm64@15.5.15':
+    resolution: {integrity: sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.4.8':
-    resolution: {integrity: sha512-xla6AOfz68a6kq3gRQccWEvFC/VRGJmA/QuSLENSO7CZX5WIEkSz7r1FdXUjtGCQ1c2M+ndUAH7opdfLK1PQbw==}
+  '@next/swc-darwin-x64@15.5.15':
+    resolution: {integrity: sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.4.8':
-    resolution: {integrity: sha512-y3fmp+1Px/SJD+5ntve5QLZnGLycsxsVPkTzAc3zUiXYSOlTPqT8ynfmt6tt4fSo1tAhDPmryXpYKEAcoAPDJw==}
+  '@next/swc-linux-arm64-gnu@15.5.15':
+    resolution: {integrity: sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.4.8':
-    resolution: {integrity: sha512-DX/L8VHzrr1CfwaVjBQr3GWCqNNFgyWJbeQ10Lx/phzbQo3JNAxUok1DZ8JHRGcL6PgMRgj6HylnLNndxn4Z6A==}
+  '@next/swc-linux-arm64-musl@15.5.15':
+    resolution: {integrity: sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.4.8':
-    resolution: {integrity: sha512-9fLAAXKAL3xEIFdKdzG5rUSvSiZTLLTCc6JKq1z04DR4zY7DbAPcRvNm3K1inVhTiQCs19ZRAgUerHiVKMZZIA==}
+  '@next/swc-linux-x64-gnu@15.5.15':
+    resolution: {integrity: sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.4.8':
-    resolution: {integrity: sha512-s45V7nfb5g7dbS7JK6XZDcapicVrMMvX2uYgOHP16QuKH/JA285oy6HcxlKqwUNaFY/UC6EvQ8QZUOo19cBKSA==}
+  '@next/swc-linux-x64-musl@15.5.15':
+    resolution: {integrity: sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.4.8':
-    resolution: {integrity: sha512-KjgeQyOAq7t/HzAJcWPGA8X+4WY03uSCZ2Ekk98S9OgCFsb6lfBE3dbUzUuEQAN2THbwYgFfxX2yFTCMm8Kehw==}
+  '@next/swc-win32-arm64-msvc@15.5.15':
+    resolution: {integrity: sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.4.8':
-    resolution: {integrity: sha512-Exsmf/+42fWVnLMaZHzshukTBxZrSwuuLKFvqhGHJ+mC1AokqieLY/XzAl3jc/CqhXLqLY3RRjkKJ9YnLPcRWg==}
+  '@next/swc-win32-x64-msvc@15.5.15':
+    resolution: {integrity: sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1089,7 +1093,7 @@ packages:
     resolution: {integrity: sha512-F0uemUqFwD3lLx5SrWXYRe9dZvMVkO0rFuMnvLiPBcagxNc23Ufl5cNXEm4Yuo8O1Mu8dgh+VjExMz1Td4vBew==}
     peerDependencies:
       next: ^13.0.0 || ^14.0.0 || ^15.0.0
-      react: 19.0.4
+      react: 19.0.5
 
   '@noble/ciphers@1.2.1':
     resolution: {integrity: sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==}
@@ -1522,8 +1526,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1535,8 +1539,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1548,8 +1552,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1561,8 +1565,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1573,7 +1577,7 @@ packages:
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1582,7 +1586,7 @@ packages:
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1591,7 +1595,7 @@ packages:
     resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1600,7 +1604,7 @@ packages:
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1610,8 +1614,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1622,7 +1626,7 @@ packages:
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1632,8 +1636,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1645,8 +1649,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1658,8 +1662,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1670,7 +1674,7 @@ packages:
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1680,8 +1684,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1692,7 +1696,7 @@ packages:
     resolution: {integrity: sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1701,7 +1705,7 @@ packages:
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1711,8 +1715,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1724,8 +1728,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1737,8 +1741,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1750,8 +1754,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1763,8 +1767,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1776,8 +1780,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1789,8 +1793,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1802,8 +1806,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1815,8 +1819,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1828,8 +1832,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1841,8 +1845,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1853,7 +1857,7 @@ packages:
     resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1862,7 +1866,7 @@ packages:
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1872,8 +1876,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1885,8 +1889,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1898,8 +1902,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1911,8 +1915,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1924,8 +1928,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1936,7 +1940,7 @@ packages:
     resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1945,7 +1949,7 @@ packages:
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1954,7 +1958,7 @@ packages:
     resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1963,7 +1967,7 @@ packages:
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1972,7 +1976,7 @@ packages:
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1981,7 +1985,7 @@ packages:
     resolution: {integrity: sha512-L7vwWlR1kTTQ3oh7g1O0CBF3YCyyTj8NmhLR+phShpyA50HCfBFKVJTpshm9PzLiKmehsrQzTYTpX9HvmC9rhw==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1990,7 +1994,7 @@ packages:
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -1999,7 +2003,7 @@ packages:
     resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2008,7 +2012,7 @@ packages:
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2017,7 +2021,7 @@ packages:
     resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2026,7 +2030,7 @@ packages:
     resolution: {integrity: sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2035,7 +2039,7 @@ packages:
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2044,7 +2048,7 @@ packages:
     resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2053,7 +2057,7 @@ packages:
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2063,8 +2067,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2076,8 +2080,8 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2095,44 +2099,44 @@ packages:
     engines: {node: '>=12.4'}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
       viem: 2.x
       wagmi: ^2.9.0
 
   '@react-aria/focus@3.19.1':
     resolution: {integrity: sha512-bix9Bu1Ue7RPcYmjwcjhB14BMu2qzfJ3tMQLqDc9pweJA66nOw8DThy3IfVr8Z7j2PHktOLf9kcbiZpydKHqzg==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   '@react-aria/interactions@3.23.0':
     resolution: {integrity: sha512-0qR1atBIWrb7FzQ+Tmr3s8uH5mQdyRH78n0krYaG8tng9+u1JlSi8DGRSaC9ezKyNB84m7vHT207xnHXGeJ3Fg==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   '@react-aria/ssr@3.9.7':
     resolution: {integrity: sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==}
     engines: {node: '>= 12'}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@react-aria/utils@3.27.0':
     resolution: {integrity: sha512-p681OtApnKOdbeN8ITfnnYqfdHS0z7GE+4l8EXlfLnr70Rp/9xicBO6d2rU+V/B3JujDw2gPWxYKEnEeh0CGCw==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   '@react-spring/animated@9.6.1':
     resolution: {integrity: sha512-ls/rJBrAqiAYozjLo5EPPLLOb1LM0lNVQcXODTC1SMtS6DbuBCPaKco5svFUQFMP2dso3O+qcC4k9FsKc0KxMQ==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@react-spring/core@9.6.1':
     resolution: {integrity: sha512-3HAAinAyCPessyQNNXe5W0OHzRfa8Yo5P748paPcmMowZ/4sMfaZ2ZB6e5x5khQI8NusOHj8nquoutd6FRY5WQ==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@react-spring/rafz@9.6.1':
     resolution: {integrity: sha512-v6qbgNRpztJFFfSE3e2W1Uz+g8KnIBs6SmzCzcVVF61GdGfGOuBrbjIcp+nUz301awVmREKi4eMQb2Ab2gGgyQ==}
@@ -2140,13 +2144,13 @@ packages:
   '@react-spring/shared@9.6.1':
     resolution: {integrity: sha512-PBFBXabxFEuF8enNLkVqMC9h5uLRBo6GQhRMQT/nRTnemVENimgRd+0ZT4yFnAQ0AxWNiJfX3qux+bW2LbG6Bw==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@react-spring/three@9.6.1':
     resolution: {integrity: sha512-Tyw2YhZPKJAX3t2FcqvpLRb71CyTe1GvT3V+i+xJzfALgpk10uPGdGaQQ5Xrzmok1340DAeg2pR/MCfaW7b8AA==}
     peerDependencies:
       '@react-three/fiber': '>=6.0'
-      react: 19.0.4
+      react: 19.0.5
       three: '>=0.126'
 
   '@react-spring/types@9.6.1':
@@ -2155,14 +2159,14 @@ packages:
   '@react-stately/utils@3.10.5':
     resolution: {integrity: sha512-iMQSGcpaecghDIh3mZEpZfoFH3ExBwTtuBEcvZ2XnGzCgQjeYXcMdIUwAfVQLXFTdHUHGF6Gu6/dFrYsCzySBQ==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@react-three/drei@9.107.2':
     resolution: {integrity: sha512-MQqRhq3bFKkYuhwp812JwdcYRy/601+jokri2m+PmuuWGy6Xi9n001pzeH47iy1Gb8KCiGHAilGXiXF87A/t4A==}
     peerDependencies:
       '@react-three/fiber': '>=8.0'
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
       three: '>=0.137'
     peerDependenciesMeta:
       react-dom:
@@ -2175,8 +2179,8 @@ packages:
       expo-asset: '>=8.4'
       expo-file-system: '>=11.0'
       expo-gl: '>=11.0'
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
       react-native: '>=0.69'
       three: '>=0.141'
     peerDependenciesMeta:
@@ -2197,13 +2201,13 @@ packages:
     resolution: {integrity: sha512-2ya1gXLDpzyfbELobi3rPHNNZZCrCfyq20GMYJD1yD7ZyBFSpRG9YSPMBnOal6A89kXanPBw273h6/Dqev0n7g==}
     peerDependencies:
       '@react-three/fiber': '>=8.0'
-      react: 19.0.4
+      react: 19.0.5
       three: '>= 0.138.0'
 
   '@react-types/shared@3.27.0':
     resolution: {integrity: sha512-gvznmLhi6JPEf0bsq7SwRYTHAKKq/wcmKqFez9sRdbED+SPMUmK5omfZ6w3EwUFQHbYUa4zPBYedQ7Knv70RMw==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@reown/appkit-common@1.7.8':
     resolution: {integrity: sha512-ridIhc/x6JOp7KbDdwGKY4zwf8/iK8EYBl+HtWrruutSLwZyVi5P8WaZa+8iajL6LcDcDF7LoyLwMTym7SRuwQ==}
@@ -2241,8 +2245,8 @@ packages:
     resolution: {integrity: sha512-Fi1C6+RebAD31aLUipOT+71kN6g7Lq/ZM0P6V5hgF/z3HPW1OXDDfRYV/Kxs5G0wA6vHQ20AKVcIq0uZz6Mf+w==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
       viem: '>=2.26.0'
 
   '@reservoir0x/relay-kit-ui@2.17.2':
@@ -2250,8 +2254,8 @@ packages:
     peerDependencies:
       '@moonpay/moonpay-react': ^1.8.3
       '@tanstack/react-query': '>=5.0.0'
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
       viem: '>=2.26.0'
       wagmi: ^2.15.6
     peerDependenciesMeta:
@@ -2449,7 +2453,7 @@ packages:
     resolution: {integrity: sha512-42T/fp8snYN19Fy/2P0Mwotu4gcdy+1Lx+uYCNcYP1o7wNGigJ7qb27sW7W34GyCCHjoCCfQgeOqDQsyY8LC9w==}
     engines: {node: '>=14.18'}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@sentry/vercel-edge@8.54.0':
     resolution: {integrity: sha512-1oct5P0iTPJOBCzNKZZ+H1ja7b1izZNCObBRhxscOsDHM4fUFwCP8MfjxGIphzj9XLibzo+4dsn6JtkxIdn5GQ==}
@@ -2990,7 +2994,7 @@ packages:
   '@stitches/react@1.2.8':
     resolution: {integrity: sha512-9g9dWI4gsSVe8bNLlb+lMkBYsnIKCZTmvqvDG+Avnn69XfmHZKiaMrx7cgTaddq7aTPPmXiTsbFcUy0xgI4+wA==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -3105,13 +3109,13 @@ packages:
   '@tanstack/react-query@5.60.6':
     resolution: {integrity: sha512-FUzSDaiPkuZCmuGqrixfRRXJV9u+nrUh9lAlA5Q3ZFrOw1Js1VeBfxi1NIcJO3ZWJdKceBqKeBJdNcWStCYZnw==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@tanstack/react-virtual@3.11.3':
     resolution: {integrity: sha512-vCU+OTylXN3hdC8RKg68tPlBPjjxtzon7Ys46MgrSLE+JhSjSTPvoQifV6DQJeJmA8Q3KT6CphJbejupx85vFw==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   '@tanstack/virtual-core@3.11.3':
     resolution: {integrity: sha512-v2mrNSnMwnPJtcVqNvV0c5roGCBqeogN8jDtgtuHCphdwBasOZ17x8UV8qpHUh+u0MLfX43c0uUHKje0s+Zb0w==}
@@ -3266,7 +3270,7 @@ packages:
   '@use-gesture/react@10.3.1':
     resolution: {integrity: sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@vanilla-extract/css@1.17.3':
     resolution: {integrity: sha512-jHivr1UPoJTX5Uel4AZSOwrCf4mO42LcdmnhJtUxZaRWhW4FviFbIfs0moAWWld7GOT+2XnuVZjjA/K32uUnMQ==}
@@ -3916,8 +3920,8 @@ packages:
   cuer@0.0.2:
     resolution: {integrity: sha512-MG1BYnnSLqBnO0dOBS1Qm/TEc9DnFa9Sz2jMA24OF4hGzs8UuPjpKBMkRPF3lrpC+7b3EzULwooX9djcvsM8IA==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
       typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
@@ -4516,8 +4520,8 @@ packages:
     resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -4530,8 +4534,8 @@ packages:
     resolution: {integrity: sha512-WpMrDfk6I5Q4T/7+LEjQOVbAD5Yb/cGbbV+LLllFEg+dHi8XZ7QecJ9aYS9bn12cWuF7gGy+uqskyAkGTWHs3w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -4616,6 +4620,7 @@ packages:
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -4928,7 +4933,7 @@ packages:
   its-fine@1.2.5:
     resolution: {integrity: sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
@@ -5038,8 +5043,8 @@ packages:
   leva@0.9.35:
     resolution: {integrity: sha512-sp/ZbHGrrzM+eq+wIAc9X7C5qFagNERYkwaulKI/xy0XrDPV67jLUSSqTCFSoSc0Uk96j3oephYoO/6I8mZNuw==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -5219,8 +5224,8 @@ packages:
   lottie-react@2.4.0:
     resolution: {integrity: sha512-pDJGj+AQlnlyHvOHFK7vLdsDcvbuqvwPZdMlJ360wrzGFurXeKPr8SiRCjLf3LrNYKANQtSsh5dz9UYQHuqx4w==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   lottie-web@5.12.2:
     resolution: {integrity: sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg==}
@@ -5392,24 +5397,24 @@ packages:
     resolution: {integrity: sha512-Z2dJWn5f/b1sb8EmuJcuDhbQTIp4RG1KBFAILgRt/y27W0ifU7Ll/os3liphUY4InyRH89uShTAk7ItAlpr0uA==}
     peerDependencies:
       next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
-      react: 19.0.4
+      react: 19.0.5
 
   next-themes@0.3.0:
     resolution: {integrity: sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
-  next@15.4.11:
-    resolution: {integrity: sha512-IJRyXal45mIsshZI5XJne/intjusslUP1F+FHVBIyMGEqbYtIq1Irdx5vdWBBg58smviPDycmDeV6txsfkv1RQ==}
+  next@15.5.15:
+    resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
       '@playwright/test': ^1.51.1
       babel-plugin-react-compiler: '*'
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -5733,7 +5738,7 @@ packages:
     peerDependencies:
       '@tanstack/react-query': '>=5.59.0'
       '@wagmi/core': '>=2.16.3'
-      react: 19.0.4
+      react: 19.0.5
       typescript: '>=5.4.0'
       viem: '>=2.37.0'
       wagmi: '>=2.0.0'
@@ -5891,7 +5896,7 @@ packages:
   qrcode.react@4.2.0:
     resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
@@ -5917,41 +5922,41 @@ packages:
   react-clientside-effect@1.2.7:
     resolution: {integrity: sha512-gce9m0Pk/xYYMEojRI9bgvqQAkl6hm7ozQvqWPyQx+kULiatdHgkNM1QG4DQRx5N9BAzWSCJmt9mMV8/KsdgVg==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   react-colorful@5.6.1:
     resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
   react-composer@5.0.3:
     resolution: {integrity: sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   react-confetti@6.1.0:
     resolution: {integrity: sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==}
     engines: {node: '>=10.18'}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
-  react-dom@19.0.4:
-    resolution: {integrity: sha512-JiVlwQwuINIQf2+XUjtRFtLxhTE6hcyX7ZyCmY0HM7I/Kgi7qyXThkzwzg6uCfu3rTg9Ofe1x8qWYrfqthIrzg==}
+  react-dom@19.0.5:
+    resolution: {integrity: sha512-yqJj7o8tlj5FiLpycpClCCTp1f1FXvMgCkFej41N1iTmVDiTeDIay6Y69sn8w9JXSCzZyCLP3fotgEhZagDZWw==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   react-dropzone@12.1.0:
     resolution: {integrity: sha512-iBYHA1rbopIvtzokEX4QubO6qk5IF/x3BtKGu74rF2JkQDXnwC4uO/lHKpaw4PJIV6iIAYOlwLv2FpiGyqHNog==}
     engines: {node: '>= 10.13'}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   react-focus-lock@2.13.2:
     resolution: {integrity: sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5960,7 +5965,7 @@ packages:
     resolution: {integrity: sha512-PUNzFwQeQ5oHiiTUO7GO/EJXGEtuun2Y1A59rLnZBBj+vNEOWt/3ERTiG1/zt7dVeJEM+4vDX/7XQ/qanuvPMg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5969,14 +5974,14 @@ packages:
     resolution: {integrity: sha512-hOHzEH+aXLQGJjEoFkz2fX5ZQCDu0VjZfhyhIqRyJrz3bwkdEloH3y+xx8/HVr8oqcm65o9/9yaK97dH+tRP2A==}
     engines: {node: '>=0.10.0'}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5986,7 +5991,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5996,7 +6001,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6006,7 +6011,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6014,11 +6019,11 @@ packages:
   react-toastify@10.0.5:
     resolution: {integrity: sha512-mNKt2jBXJg4O7pSdbNUfDdTsK9FIdikfsIE/yUCxbAEXl4HMyJaivrVFcn3Elvt5xvCQYhUZm+hqTIu1UXM3Pw==}
     peerDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4
+      react: 19.0.5
+      react-dom: 19.0.5
 
-  react@19.0.4:
-    resolution: {integrity: sha512-6RpEg9/n0sThnO+2CaMLWuvL1iyctm9/lcSTwvmyCoJYD5eiIrwxevXtrMqrtUr96HCdQB8/Yf+oK1QGy8kXEQ==}
+  react@19.0.5:
+    resolution: {integrity: sha512-yIoQWl4moQfHFKNGmyJavhOki09GwCRcMFuXv3y3KMXoQrGnDi0ZHGe4H9EtQE+jrMWU4hgxaILMS4rxTkJdGw==}
     engines: {node: '>=0.10.0'}
 
   readable-stream@2.3.8:
@@ -6350,7 +6355,7 @@ packages:
     peerDependencies:
       '@babel/core': '*'
       babel-plugin-macros: '*'
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -6376,7 +6381,7 @@ packages:
   suspend-react@0.1.3:
     resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -6696,7 +6701,7 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6704,14 +6709,14 @@ packages:
   use-intl@3.26.3:
     resolution: {integrity: sha512-yY0a2YseO17cKwHA9M6fcpiEJ2Uo81DEU0NOUxNTp6lJVNOuI6nULANPVVht6IFdrYFtlsMmMoc97+Eq9/Tnng==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6719,18 +6724,18 @@ packages:
   use-sync-external-store@1.2.0:
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   use-sync-external-store@1.4.0:
     resolution: {integrity: sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   usehooks-ts@3.1.1:
     resolution: {integrity: sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==}
     engines: {node: '>=16.15.0'}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   utf-8-validate@5.0.10:
     resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
@@ -6748,10 +6753,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8n@1.5.1:
@@ -6762,7 +6769,7 @@ packages:
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6801,7 +6808,7 @@ packages:
     resolution: {integrity: sha512-Sk2e40gfo68gbJ6lHkpIwCMkH76rO0+toCPjf3PzdQX37rZo9042DdNTYcSg3zhnx8abFJtrk/5vAWfR8APTDw==}
     peerDependencies:
       '@tanstack/react-query': '>=5.0.0'
-      react: 19.0.4
+      react: 19.0.5
       typescript: '>=5.0.4'
       viem: 2.x
     peerDependenciesMeta:
@@ -7006,7 +7013,7 @@ packages:
     resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}
     engines: {node: '>=12.7.0'}
     peerDependencies:
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       react:
         optional: true
@@ -7017,7 +7024,7 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       immer: '>=9.0.6'
-      react: 19.0.4
+      react: 19.0.5
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -7032,7 +7039,7 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       immer: '>=9.0.6'
-      react: 19.0.4
+      react: 19.0.5
       use-sync-external-store: '>=1.2.0'
     peerDependenciesMeta:
       '@types/react':
@@ -7050,7 +7057,7 @@ packages:
     peerDependencies:
       '@types/react': 19.0.7
       immer: '>=9.0.6'
-      react: 19.0.4
+      react: 19.0.5
       use-sync-external-store: '>=1.2.0'
     peerDependenciesMeta:
       '@types/react':
@@ -7183,7 +7190,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@base-org/account@1.1.1(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@base-org/account@1.1.1(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
@@ -7192,7 +7199,7 @@ snapshots:
       ox: 0.6.9(typescript@5.7.3)(zod@3.24.1)
       preact: 10.24.2
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      zustand: 5.0.3(@types/react@19.0.7)(react@19.0.4)(use-sync-external-store@1.4.0(react@19.0.4))
+      zustand: 5.0.3(@types/react@19.0.7)(react@19.0.5)(use-sync-external-store@1.4.0(react@19.0.5))
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -7228,7 +7235,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@coinbase/wallet-sdk@4.3.6(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@coinbase/wallet-sdk@4.3.6(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
       '@noble/hashes': 1.4.0
       clsx: 1.2.1
@@ -7237,7 +7244,7 @@ snapshots:
       ox: 0.6.9(typescript@5.7.3)(zod@3.24.1)
       preact: 10.24.2
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      zustand: 5.0.3(@types/react@19.0.7)(react@19.0.4)(use-sync-external-store@1.4.0(react@19.0.4))
+      zustand: 5.0.3(@types/react@19.0.7)(react@19.0.5)(use-sync-external-store@1.4.0(react@19.0.5))
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -7431,18 +7438,18 @@ snapshots:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.6(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@floating-ui/react-dom@2.1.6(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@floating-ui/dom': 1.7.4
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
-  '@floating-ui/react@0.26.28(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@floating-ui/react@0.26.28(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       '@floating-ui/utils': 0.2.10
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
       tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.10': {}
@@ -7483,11 +7490,11 @@ snapshots:
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
 
-  '@fortawesome/react-fontawesome@0.2.6(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.0.4)':
+  '@fortawesome/react-fontawesome@0.2.6(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.0.5)':
     dependencies:
       '@fortawesome/fontawesome-svg-core': 6.7.2
       prop-types: 15.8.1
-      react: 19.0.4
+      react: 19.0.5
 
   '@gemini-wallet/core@0.2.0(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))':
     dependencies:
@@ -7497,18 +7504,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@headlessui/react@2.2.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@headlessui/react@2.2.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@floating-ui/react': 0.26.28(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@react-aria/focus': 3.19.1(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@react-aria/interactions': 3.23.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@tanstack/react-virtual': 3.11.3(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@floating-ui/react': 0.26.28(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@react-aria/focus': 3.19.1(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@react-aria/interactions': 3.23.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@tanstack/react-virtual': 3.11.3(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
-  '@hookform/resolvers@3.9.1(react-hook-form@7.54.1(react@19.0.4))':
+  '@hookform/resolvers@3.9.1(react-hook-form@7.54.1(react@19.0.5))':
     dependencies:
-      react-hook-form: 7.54.1(react@19.0.4)
+      react-hook-form: 7.54.1(react@19.0.5)
 
   '@humanfs/core@0.19.1': {}
 
@@ -7687,18 +7694,18 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@inkonchain/ink-kit@0.9.1-beta.19(@tanstack/react-query@5.60.6(react@19.0.4))(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(tailwindcss@4.0.8)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))':
+  '@inkonchain/ink-kit@0.9.1-beta.19(@tanstack/react-query@5.60.6(react@19.0.5))(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(tailwindcss@4.0.8)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))':
     dependencies:
-      '@headlessui/react': 2.2.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@tanstack/react-query': 5.60.6(react@19.0.4)
+      '@headlessui/react': 2.2.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@tanstack/react-query': 5.60.6(react@19.0.5)
       class-variance-authority: 0.7.1
       clsx: 2.1.1
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
       tailwind-merge: 2.6.0
       tailwindcss: 4.0.8
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      wagmi: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
+      wagmi: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -7925,40 +7932,40 @@ snapshots:
 
   '@msgpack/msgpack@3.1.2': {}
 
-  '@next/env@15.4.11': {}
+  '@next/env@15.5.15': {}
 
   '@next/eslint-plugin-next@15.0.3':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.4.8':
+  '@next/swc-darwin-arm64@15.5.15':
     optional: true
 
-  '@next/swc-darwin-x64@15.4.8':
+  '@next/swc-darwin-x64@15.5.15':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.4.8':
+  '@next/swc-linux-arm64-gnu@15.5.15':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.4.8':
+  '@next/swc-linux-arm64-musl@15.5.15':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.4.8':
+  '@next/swc-linux-x64-gnu@15.5.15':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.4.8':
+  '@next/swc-linux-x64-musl@15.5.15':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.4.8':
+  '@next/swc-win32-arm64-msvc@15.5.15':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.4.8':
+  '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
-  '@next/third-parties@15.1.6(next@15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6))(react@19.0.4)':
+  '@next/third-parties@15.1.6(next@15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6))(react@19.0.5)':
     dependencies:
-      next: 15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6)
-      react: 19.0.4
+      next: 15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6)
+      react: 19.0.5
       third-party-capital: 1.0.20
 
   '@noble/ciphers@1.2.1': {}
@@ -8585,535 +8592,535 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-arrow@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-arrow@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-compose-refs@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-compose-refs@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-context@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-context@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-context@1.1.2(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-context@1.1.2(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.5)
       aria-hidden: 1.2.6
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
-      react-remove-scroll: 2.7.1(@types/react@19.0.7)(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
+      react-remove-scroll: 2.7.1(@types/react@19.0.7)(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-direction@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-id@1.1.0(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-id@1.1.0(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-id@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-id@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.5)
       aria-hidden: 1.2.6
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
-      react-remove-scroll: 2.7.1(@types/react@19.0.7)(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
+      react-remove-scroll: 2.7.1(@types/react@19.0.7)(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.5)
       aria-hidden: 1.2.6
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
-      react-remove-scroll: 2.7.1(@types/react@19.0.7)(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
+      react-remove-scroll: 2.7.1(@types/react@19.0.7)(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-popper@1.2.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-popper@1.2.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-arrow': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-rect': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-size': 1.1.0(@types/react@19.0.7)(react@19.0.4)
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-arrow': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.0.7)(react@19.0.5)
       '@radix-ui/rect': 1.1.0
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.0.7)(react@19.0.4)
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.0.7)(react@19.0.5)
       '@radix-ui/rect': 1.1.1
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-portal@1.1.4(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-portal@1.1.4(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-presence@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-presence@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-slot@1.1.2(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-slot@1.1.2(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-slot@1.2.3(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-slot@1.2.3(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-tooltip@1.1.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-tooltip@1.1.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
-      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-context': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-id': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-popper': 1.2.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-portal': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-visually-hidden': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-popper': 1.2.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-portal': 1.1.4(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-visually-hidden': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.0.7)(react@19.0.4)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.0.7)(react@19.0.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-escape-keydown@1.1.0(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-previous@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-rect@1.1.0(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-rect@1.1.0(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
       '@radix-ui/rect': 1.1.0
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
       '@radix-ui/rect': 1.1.1
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-size@1.1.0(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-size@1.1.0(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.0.7)(react@19.0.4)':
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.0.7)(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
     optionalDependencies:
       '@types/react': 19.0.7
 
-  '@radix-ui/react-visually-hidden@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-visually-hidden@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
@@ -9122,106 +9129,106 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rainbow-me/rainbowkit@2.2.8(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(typescript@5.7.3)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))':
+  '@rainbow-me/rainbowkit@2.2.8(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(typescript@5.7.3)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))':
     dependencies:
-      '@tanstack/react-query': 5.60.6(react@19.0.4)
+      '@tanstack/react-query': 5.60.6(react@19.0.5)
       '@vanilla-extract/css': 1.17.3
       '@vanilla-extract/dynamic': 2.1.4
       '@vanilla-extract/sprinkles': 1.6.4(@vanilla-extract/css@1.17.3)
       clsx: 2.1.1
-      cuer: 0.0.2(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(typescript@5.7.3)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
-      react-remove-scroll: 2.6.2(@types/react@19.0.7)(react@19.0.4)
+      cuer: 0.0.2(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(typescript@5.7.3)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
+      react-remove-scroll: 2.6.2(@types/react@19.0.7)(react@19.0.5)
       ua-parser-js: 1.0.40
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      wagmi: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
+      wagmi: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
     transitivePeerDependencies:
       - '@types/react'
       - babel-plugin-macros
       - typescript
 
-  '@react-aria/focus@3.19.1(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@react-aria/focus@3.19.1(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@react-aria/interactions': 3.23.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@react-aria/utils': 3.27.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@react-types/shared': 3.27.0(react@19.0.4)
+      '@react-aria/interactions': 3.23.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@react-aria/utils': 3.27.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@react-types/shared': 3.27.0(react@19.0.5)
       '@swc/helpers': 0.5.15
       clsx: 2.1.1
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
-  '@react-aria/interactions@3.23.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@react-aria/interactions@3.23.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@react-aria/ssr': 3.9.7(react@19.0.4)
-      '@react-aria/utils': 3.27.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@react-types/shared': 3.27.0(react@19.0.4)
+      '@react-aria/ssr': 3.9.7(react@19.0.5)
+      '@react-aria/utils': 3.27.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@react-types/shared': 3.27.0(react@19.0.5)
       '@swc/helpers': 0.5.15
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
-  '@react-aria/ssr@3.9.7(react@19.0.4)':
+  '@react-aria/ssr@3.9.7(react@19.0.5)':
     dependencies:
       '@swc/helpers': 0.5.15
-      react: 19.0.4
+      react: 19.0.5
 
-  '@react-aria/utils@3.27.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@react-aria/utils@3.27.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
-      '@react-aria/ssr': 3.9.7(react@19.0.4)
-      '@react-stately/utils': 3.10.5(react@19.0.4)
-      '@react-types/shared': 3.27.0(react@19.0.4)
+      '@react-aria/ssr': 3.9.7(react@19.0.5)
+      '@react-stately/utils': 3.10.5(react@19.0.5)
+      '@react-types/shared': 3.27.0(react@19.0.5)
       '@swc/helpers': 0.5.15
       clsx: 2.1.1
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
-  '@react-spring/animated@9.6.1(react@19.0.4)':
+  '@react-spring/animated@9.6.1(react@19.0.5)':
     dependencies:
-      '@react-spring/shared': 9.6.1(react@19.0.4)
+      '@react-spring/shared': 9.6.1(react@19.0.5)
       '@react-spring/types': 9.6.1
-      react: 19.0.4
+      react: 19.0.5
 
-  '@react-spring/core@9.6.1(react@19.0.4)':
+  '@react-spring/core@9.6.1(react@19.0.5)':
     dependencies:
-      '@react-spring/animated': 9.6.1(react@19.0.4)
+      '@react-spring/animated': 9.6.1(react@19.0.5)
       '@react-spring/rafz': 9.6.1
-      '@react-spring/shared': 9.6.1(react@19.0.4)
+      '@react-spring/shared': 9.6.1(react@19.0.5)
       '@react-spring/types': 9.6.1
-      react: 19.0.4
+      react: 19.0.5
 
   '@react-spring/rafz@9.6.1': {}
 
-  '@react-spring/shared@9.6.1(react@19.0.4)':
+  '@react-spring/shared@9.6.1(react@19.0.5)':
     dependencies:
       '@react-spring/rafz': 9.6.1
       '@react-spring/types': 9.6.1
-      react: 19.0.4
+      react: 19.0.5
 
-  '@react-spring/three@9.6.1(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0))(react@19.0.4)(three@0.165.0)':
+  '@react-spring/three@9.6.1(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0))(react@19.0.5)(three@0.165.0)':
     dependencies:
-      '@react-spring/animated': 9.6.1(react@19.0.4)
-      '@react-spring/core': 9.6.1(react@19.0.4)
-      '@react-spring/shared': 9.6.1(react@19.0.4)
+      '@react-spring/animated': 9.6.1(react@19.0.5)
+      '@react-spring/core': 9.6.1(react@19.0.5)
+      '@react-spring/shared': 9.6.1(react@19.0.5)
       '@react-spring/types': 9.6.1
-      '@react-three/fiber': 9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0)
-      react: 19.0.4
+      '@react-three/fiber': 9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0)
+      react: 19.0.5
       three: 0.165.0
 
   '@react-spring/types@9.6.1': {}
 
-  '@react-stately/utils@3.10.5(react@19.0.4)':
+  '@react-stately/utils@3.10.5(react@19.0.5)':
     dependencies:
       '@swc/helpers': 0.5.15
-      react: 19.0.4
+      react: 19.0.5
 
-  '@react-three/drei@9.107.2(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0))(@types/react@19.0.7)(@types/three@0.170.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0)':
+  '@react-three/drei@9.107.2(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0))(@types/react@19.0.7)(@types/three@0.170.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@mediapipe/tasks-vision': 0.10.8
       '@monogrid/gainmap-js': 3.1.0(three@0.165.0)
-      '@react-spring/three': 9.6.1(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0))(react@19.0.4)(three@0.165.0)
-      '@react-three/fiber': 9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0)
-      '@use-gesture/react': 10.3.1(react@19.0.4)
+      '@react-spring/three': 9.6.1(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0))(react@19.0.5)(three@0.165.0)
+      '@react-three/fiber': 9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0)
+      '@use-gesture/react': 10.3.1(react@19.0.5)
       camera-controls: 2.9.0(three@0.165.0)
       cross-env: 7.0.3
       detect-gpu: 5.0.66
@@ -9229,27 +9236,27 @@ snapshots:
       hls.js: 1.3.5
       maath: 0.10.7(@types/three@0.170.0)(three@0.165.0)
       meshline: 3.3.1(three@0.165.0)
-      react: 19.0.4
-      react-composer: 5.0.3(react@19.0.4)
+      react: 19.0.5
+      react-composer: 5.0.3(react@19.0.5)
       stats-gl: 2.4.2(@types/three@0.170.0)(three@0.165.0)
       stats.js: 0.17.0
-      suspend-react: 0.1.3(react@19.0.4)
+      suspend-react: 0.1.3(react@19.0.5)
       three: 0.165.0
       three-mesh-bvh: 0.7.6(three@0.165.0)
       three-stdlib: 2.35.13(three@0.165.0)
       troika-three-text: 0.49.1(three@0.165.0)
-      tunnel-rat: 0.1.2(@types/react@19.0.7)(react@19.0.4)
+      tunnel-rat: 0.1.2(@types/react@19.0.7)(react@19.0.5)
       utility-types: 3.11.0
       uuid: 9.0.1
-      zustand: 3.7.2(react@19.0.4)
+      zustand: 3.7.2(react@19.0.5)
     optionalDependencies:
-      react-dom: 19.0.4(react@19.0.4)
+      react-dom: 19.0.5(react@19.0.5)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/three'
       - immer
 
-  '@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0)':
+  '@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@types/debounce': 1.2.4
@@ -9258,35 +9265,35 @@ snapshots:
       base64-js: 1.5.1
       buffer: 6.0.3
       debounce: 1.2.1
-      its-fine: 1.2.5(@types/react@19.0.7)(react@19.0.4)
-      react: 19.0.4
-      react-reconciler: 0.31.0-rc.0(react@19.0.4)
+      its-fine: 1.2.5(@types/react@19.0.7)(react@19.0.5)
+      react: 19.0.5
+      react-reconciler: 0.31.0-rc.0(react@19.0.5)
       scheduler: 0.25.0-rc.0
-      suspend-react: 0.1.3(react@19.0.4)
+      suspend-react: 0.1.3(react@19.0.5)
       three: 0.165.0
-      zustand: 4.5.6(@types/react@19.0.7)(react@19.0.4)
+      zustand: 4.5.6(@types/react@19.0.7)(react@19.0.5)
     optionalDependencies:
-      react-dom: 19.0.4(react@19.0.4)
+      react-dom: 19.0.5(react@19.0.5)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@react-three/postprocessing@2.16.2(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0))(@types/three@0.170.0)(react@19.0.4)(three@0.165.0)':
+  '@react-three/postprocessing@2.16.2(@react-three/fiber@9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0))(@types/three@0.170.0)(react@19.0.5)(three@0.165.0)':
     dependencies:
-      '@react-three/fiber': 9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(three@0.165.0)
+      '@react-three/fiber': 9.0.0-rc.0(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(three@0.165.0)
       buffer: 6.0.3
       maath: 0.6.0(@types/three@0.170.0)(three@0.165.0)
       n8ao: 1.9.4(postprocessing@6.35.5(three@0.165.0))(three@0.165.0)
       postprocessing: 6.35.5(three@0.165.0)
-      react: 19.0.4
+      react: 19.0.5
       three: 0.165.0
       three-stdlib: 2.35.13(three@0.165.0)
     transitivePeerDependencies:
       - '@types/three'
 
-  '@react-types/shared@3.27.0(react@19.0.4)':
+  '@react-types/shared@3.27.0(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@reown/appkit-common@1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.22.4)':
     dependencies:
@@ -9310,12 +9317,12 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-controllers@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@reown/appkit-controllers@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.4)
+      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.5)
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -9344,14 +9351,14 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-pay@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@reown/appkit-pay@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.4))(zod@3.24.1)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.5))(zod@3.24.1)
       lit: 3.3.0
-      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.4)
+      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.5)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9383,12 +9390,12 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
-  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.4))(zod@3.24.1)':
+  '@reown/appkit-scaffold-ui@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.5))(zod@3.24.1)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.4))(zod@3.24.1)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.5))(zod@3.24.1)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
     transitivePeerDependencies:
@@ -9419,10 +9426,10 @@ snapshots:
       - valtio
       - zod
 
-  '@reown/appkit-ui@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@reown/appkit-ui@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
       lit: 3.3.0
       qrcode: 1.5.3
@@ -9453,15 +9460,15 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@reown/appkit-utils@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.4))(zod@3.24.1)':
+  '@reown/appkit-utils@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.5))(zod@3.24.1)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@reown/appkit-polyfills': 1.7.8
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
       '@walletconnect/logger': 2.1.2
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.4)
+      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.5)
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -9501,20 +9508,20 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@reown/appkit@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@reown/appkit@1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
       '@reown/appkit-common': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-pay': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit-controllers': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit-pay': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@reown/appkit-polyfills': 1.7.8
-      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.4))(zod@3.24.1)
-      '@reown/appkit-ui': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@reown/appkit-utils': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.4))(zod@3.24.1)
+      '@reown/appkit-scaffold-ui': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.5))(zod@3.24.1)
+      '@reown/appkit-ui': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit-utils': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(valtio@1.13.2(@types/react@19.0.7)(react@19.0.5))(zod@3.24.1)
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
       '@walletconnect/types': 2.21.0
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       bs58: 6.0.0
-      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.4)
+      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.5)
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -9545,51 +9552,51 @@ snapshots:
 
   '@reservoir0x/relay-design-system@0.0.2': {}
 
-  '@reservoir0x/relay-kit-hooks@1.12.0(@tanstack/react-query@5.60.6(react@19.0.4))(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))':
+  '@reservoir0x/relay-kit-hooks@1.12.0(@tanstack/react-query@5.60.6(react@19.0.5))(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))':
     dependencies:
       '@reservoir0x/relay-sdk': 2.4.0(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
-      '@tanstack/react-query': 5.60.6(react@19.0.4)
+      '@tanstack/react-query': 5.60.6(react@19.0.5)
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
       axios: 1.11.0
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     transitivePeerDependencies:
       - debug
 
-  '@reservoir0x/relay-kit-ui@2.17.2(@pandacss/dev@0.51.1(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.7.3))(@radix-ui/colors@3.0.0)(@tanstack/react-query@5.60.6(react@19.0.4))(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))':
+  '@reservoir0x/relay-kit-ui@2.17.2(@pandacss/dev@0.51.1(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.7.3))(@radix-ui/colors@3.0.0)(@tanstack/react-query@5.60.6(react@19.0.5))(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))':
     dependencies:
       '@fortawesome/fontawesome-svg-core': 6.7.2
       '@fortawesome/free-solid-svg-icons': 6.7.2
-      '@fortawesome/react-fontawesome': 0.2.6(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.0.4)
+      '@fortawesome/react-fontawesome': 0.2.6(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.0.5)
       '@noble/hashes': 1.8.0
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-tooltip': 1.1.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-tooltip': 1.1.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       '@reservoir0x/relay-design-system': 0.0.2
-      '@reservoir0x/relay-kit-hooks': 1.12.0(@tanstack/react-query@5.60.6(react@19.0.4))(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
+      '@reservoir0x/relay-kit-hooks': 1.12.0(@tanstack/react-query@5.60.6(react@19.0.5))(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
       '@reservoir0x/relay-sdk': 2.4.0(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
-      '@tanstack/react-query': 5.60.6(react@19.0.4)
+      '@tanstack/react-query': 5.60.6(react@19.0.5)
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
       axios: 1.11.0
       dayjs: 1.11.18
-      framer-motion: 11.18.2(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
+      framer-motion: 11.18.2(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
       fuse.js: 7.1.0
       pandacss-preset-radix-colors: 0.2.0(@pandacss/dev@0.51.1(jsdom@26.0.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(typescript@5.7.3))(@radix-ui/colors@3.0.0)
-      qrcode.react: 4.2.0(react@19.0.4)
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
-      usehooks-ts: 3.1.1(react@19.0.4)
+      qrcode.react: 4.2.0(react@19.0.5)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
+      usehooks-ts: 3.1.1(react@19.0.5)
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      wagmi: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
+      wagmi: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@pandacss/dev'
@@ -9824,7 +9831,7 @@ snapshots:
 
   '@sentry/core@8.54.0': {}
 
-  '@sentry/nextjs@8.54.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6))(react@19.0.4)(webpack@5.97.1)':
+  '@sentry/nextjs@8.54.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6))(react@19.0.5)(webpack@5.97.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.28.0
@@ -9833,11 +9840,11 @@ snapshots:
       '@sentry/core': 8.54.0
       '@sentry/node': 8.54.0
       '@sentry/opentelemetry': 8.54.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.28.0)
-      '@sentry/react': 8.54.0(react@19.0.4)
+      '@sentry/react': 8.54.0(react@19.0.5)
       '@sentry/vercel-edge': 8.54.0
       '@sentry/webpack-plugin': 2.22.7(webpack@5.97.1)
       chalk: 3.0.0
-      next: 15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6)
+      next: 15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6)
       resolve: 1.22.8
       rollup: 3.29.5
       stacktrace-parser: 0.1.10
@@ -9901,12 +9908,12 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.28.0
       '@sentry/core': 8.54.0
 
-  '@sentry/react@8.54.0(react@19.0.4)':
+  '@sentry/react@8.54.0(react@19.0.5)':
     dependencies:
       '@sentry/browser': 8.54.0
       '@sentry/core': 8.54.0
       hoist-non-react-statics: 3.3.2
-      react: 19.0.4
+      react: 19.0.5
 
   '@sentry/vercel-edge@8.54.0':
     dependencies:
@@ -10566,9 +10573,9 @@ snapshots:
       '@stdlib/utils-constructor-name': 0.0.8
       '@stdlib/utils-global': 0.0.7
 
-  '@stitches/react@1.2.8(react@19.0.4)':
+  '@stitches/react@1.2.8(react@19.0.5)':
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -10650,16 +10657,16 @@ snapshots:
 
   '@tanstack/query-core@5.60.6': {}
 
-  '@tanstack/react-query@5.60.6(react@19.0.4)':
+  '@tanstack/react-query@5.60.6(react@19.0.5)':
     dependencies:
       '@tanstack/query-core': 5.60.6
-      react: 19.0.4
+      react: 19.0.5
 
-  '@tanstack/react-virtual@3.11.3(react-dom@19.0.4(react@19.0.4))(react@19.0.4)':
+  '@tanstack/react-virtual@3.11.3(react-dom@19.0.5(react@19.0.5))(react@19.0.5)':
     dependencies:
       '@tanstack/virtual-core': 3.11.3
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
   '@tanstack/virtual-core@3.11.3': {}
 
@@ -10843,10 +10850,10 @@ snapshots:
 
   '@use-gesture/core@10.3.1': {}
 
-  '@use-gesture/react@10.3.1(react@19.0.4)':
+  '@use-gesture/react@10.3.1(react@19.0.5)':
     dependencies:
       '@use-gesture/core': 10.3.1
-      react: 19.0.4
+      react: 19.0.5
 
   '@vanilla-extract/css@1.17.3':
     dependencies:
@@ -10907,18 +10914,18 @@ snapshots:
 
   '@vue/shared@3.4.19': {}
 
-  '@wagmi/connectors@5.11.2(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)))(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))(zod@3.24.1)':
+  '@wagmi/connectors@5.11.2(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)))(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))(zod@3.24.1)':
     dependencies:
-      '@base-org/account': 1.1.1(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@base-org/account': 1.1.1(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(utf-8-validate@5.0.10)(zod@3.24.1)
       '@gemini-wallet/core': 0.2.0(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
       '@metamask/sdk': 0.33.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      '@wagmi/core': 2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
-      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@wagmi/core': 2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
+      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      porto: 0.2.19(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)))(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
+      porto: 0.2.19(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)))(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     optionalDependencies:
       typescript: 5.7.3
@@ -10953,12 +10960,12 @@ snapshots:
       - wagmi
       - zod
 
-  '@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))':
+  '@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.7.3)
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
-      zustand: 5.0.0(@types/react@19.0.7)(react@19.0.4)(use-sync-external-store@1.4.0(react@19.0.4))
+      zustand: 5.0.0(@types/react@19.0.7)(react@19.0.5)(use-sync-external-store@1.4.0(react@19.0.5))
     optionalDependencies:
       '@tanstack/query-core': 5.60.6
       typescript: 5.7.3
@@ -11101,9 +11108,9 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@walletconnect/ethereum-provider@2.21.1(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
-      '@reown/appkit': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
@@ -11141,9 +11148,9 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@walletconnect/ethereum-provider@2.21.4(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
+  '@walletconnect/ethereum-provider@2.21.4(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)':
     dependencies:
-      '@reown/appkit': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
+      '@reown/appkit': 1.7.8(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       '@walletconnect/jsonrpc-http-connection': 1.0.8
       '@walletconnect/jsonrpc-provider': 1.0.14
       '@walletconnect/jsonrpc-types': 1.0.4
@@ -12239,11 +12246,11 @@ snapshots:
 
   csstype@3.1.3: {}
 
-  cuer@0.0.2(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(typescript@5.7.3):
+  cuer@0.0.2(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(typescript@5.7.3):
     dependencies:
       qr: 0.5.0
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
     optionalDependencies:
       typescript: 5.7.3
 
@@ -12336,9 +12343,9 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.0.7)(react@19.0.4)):
+  derive-valtio@0.1.0(valtio@1.13.2(@types/react@19.0.7)(react@19.0.5)):
     dependencies:
-      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.4)
+      valtio: 1.13.2(@types/react@19.0.7)(react@19.0.5)
 
   destr@2.0.3: {}
 
@@ -12960,21 +12967,21 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
-  framer-motion@11.18.2(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
+  framer-motion@11.18.2(react-dom@19.0.5(react@19.0.5))(react@19.0.5):
     dependencies:
       motion-dom: 11.18.1
       motion-utils: 11.18.1
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
-  framer-motion@12.0.0-alpha.1(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
+  framer-motion@12.0.0-alpha.1(react-dom@19.0.5(react@19.0.5))(react@19.0.5):
     dependencies:
       tslib: 2.8.1
     optionalDependencies:
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
   fs-extra@11.2.0:
     dependencies:
@@ -13377,10 +13384,10 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
-  its-fine@1.2.5(@types/react@19.0.7)(react@19.0.4):
+  its-fine@1.2.5(@types/react@19.0.7)(react@19.0.5):
     dependencies:
       '@types/react-reconciler': 0.28.9(@types/react@19.0.7)
-      react: 19.0.4
+      react: 19.0.5
     transitivePeerDependencies:
       - '@types/react'
 
@@ -13494,21 +13501,21 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
-  leva@0.9.35(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
+  leva@0.9.35(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5):
     dependencies:
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@radix-ui/react-tooltip': 1.1.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      '@stitches/react': 1.2.8(react@19.0.4)
-      '@use-gesture/react': 10.3.1(react@19.0.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@radix-ui/react-tooltip': 1.1.8(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      '@stitches/react': 1.2.8(react@19.0.5)
+      '@use-gesture/react': 10.3.1(react@19.0.5)
       colord: 2.9.3
       dequal: 2.0.3
       merge-value: 1.0.0
-      react: 19.0.4
-      react-colorful: 5.6.1(react-dom@19.0.4(react@19.0.4))(react@19.0.4)
-      react-dom: 19.0.4(react@19.0.4)
-      react-dropzone: 12.1.0(react@19.0.4)
+      react: 19.0.5
+      react-colorful: 5.6.1(react-dom@19.0.5(react@19.0.5))(react@19.0.5)
+      react-dom: 19.0.5(react@19.0.5)
+      react-dropzone: 12.1.0(react@19.0.5)
       v8n: 1.5.1
-      zustand: 3.7.2(react@19.0.4)
+      zustand: 3.7.2(react@19.0.5)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -13652,11 +13659,11 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lottie-react@2.4.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
+  lottie-react@2.4.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5):
     dependencies:
       lottie-web: 5.12.2
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
   lottie-web@5.12.2: {}
 
@@ -13797,37 +13804,37 @@ snapshots:
     dependencies:
       '@segment/isodate': 1.0.3
 
-  next-intl@3.25.1(next@15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6))(react@19.0.4):
+  next-intl@3.25.1(next@15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6))(react@19.0.5):
     dependencies:
       '@formatjs/intl-localematcher': 0.5.10
       negotiator: 1.0.0
-      next: 15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6)
-      react: 19.0.4
-      use-intl: 3.26.3(react@19.0.4)
+      next: 15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6)
+      react: 19.0.5
+      use-intl: 3.26.3(react@19.0.5)
 
-  next-themes@0.3.0(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
+  next-themes@0.3.0(react-dom@19.0.5(react@19.0.5))(react@19.0.5):
     dependencies:
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
-  next@15.4.11(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.4(react@19.0.4))(react@19.0.4)(sass@1.77.6):
+  next@15.5.15(@babel/core@7.26.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.45.0)(react-dom@19.0.5(react@19.0.5))(react@19.0.5)(sass@1.77.6):
     dependencies:
-      '@next/env': 15.4.11
+      '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001741
       postcss: 8.4.31
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
-      styled-jsx: 5.1.6(@babel/core@7.26.7)(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
+      styled-jsx: 5.1.6(@babel/core@7.26.7)(react@19.0.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.4.8
-      '@next/swc-darwin-x64': 15.4.8
-      '@next/swc-linux-arm64-gnu': 15.4.8
-      '@next/swc-linux-arm64-musl': 15.4.8
-      '@next/swc-linux-x64-gnu': 15.4.8
-      '@next/swc-linux-x64-musl': 15.4.8
-      '@next/swc-win32-arm64-msvc': 15.4.8
-      '@next/swc-win32-x64-msvc': 15.4.8
+      '@next/swc-darwin-arm64': 15.5.15
+      '@next/swc-darwin-x64': 15.5.15
+      '@next/swc-linux-arm64-gnu': 15.5.15
+      '@next/swc-linux-arm64-musl': 15.5.15
+      '@next/swc-linux-x64-gnu': 15.5.15
+      '@next/swc-linux-x64-musl': 15.5.15
+      '@next/swc-win32-arm64-msvc': 15.5.15
+      '@next/swc-win32-x64-msvc': 15.5.15
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.45.0
       sass: 1.77.6
@@ -14195,21 +14202,21 @@ snapshots:
 
   pony-cause@2.1.11: {}
 
-  porto@0.2.19(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)))(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)):
+  porto@0.2.19(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)))(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)):
     dependencies:
-      '@wagmi/core': 2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
+      '@wagmi/core': 2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
       hono: 4.9.8
       idb-keyval: 6.2.1
       mipd: 0.0.7(typescript@5.7.3)
       ox: 0.9.7(typescript@5.7.3)(zod@4.1.11)
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
       zod: 4.1.11
-      zustand: 5.0.3(@types/react@19.0.7)(react@19.0.4)(use-sync-external-store@1.4.0(react@19.0.4))
+      zustand: 5.0.3(@types/react@19.0.7)(react@19.0.5)(use-sync-external-store@1.4.0(react@19.0.5))
     optionalDependencies:
-      '@tanstack/react-query': 5.60.6(react@19.0.4)
-      react: 19.0.4
+      '@tanstack/react-query': 5.60.6(react@19.0.5)
+      react: 19.0.5
       typescript: 5.7.3
-      wagmi: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
+      wagmi: 2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -14332,9 +14339,9 @@ snapshots:
 
   qr@0.5.0: {}
 
-  qrcode.react@4.2.0(react@19.0.4):
+  qrcode.react@4.2.0(react@19.0.5):
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   qrcode@1.5.3:
     dependencies:
@@ -14360,106 +14367,106 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  react-clientside-effect@1.2.7(react@19.0.4):
+  react-clientside-effect@1.2.7(react@19.0.5):
     dependencies:
       '@babel/runtime': 7.28.4
-      react: 19.0.4
+      react: 19.0.5
 
-  react-colorful@5.6.1(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
+  react-colorful@5.6.1(react-dom@19.0.5(react@19.0.5))(react@19.0.5):
     dependencies:
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
-  react-composer@5.0.3(react@19.0.4):
+  react-composer@5.0.3(react@19.0.5):
     dependencies:
       prop-types: 15.8.1
-      react: 19.0.4
+      react: 19.0.5
 
-  react-confetti@6.1.0(react@19.0.4):
+  react-confetti@6.1.0(react@19.0.5):
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
       tween-functions: 1.2.0
 
-  react-dom@19.0.4(react@19.0.4):
+  react-dom@19.0.5(react@19.0.5):
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
       scheduler: 0.25.0
 
-  react-dropzone@12.1.0(react@19.0.4):
+  react-dropzone@12.1.0(react@19.0.5):
     dependencies:
       attr-accept: 2.2.5
       file-selector: 0.5.0
       prop-types: 15.8.1
-      react: 19.0.4
+      react: 19.0.5
 
-  react-focus-lock@2.13.2(@types/react@19.0.7)(react@19.0.4):
+  react-focus-lock@2.13.2(@types/react@19.0.7)(react@19.0.5):
     dependencies:
       '@babel/runtime': 7.28.4
       focus-lock: 1.3.6
       prop-types: 15.8.1
-      react: 19.0.4
-      react-clientside-effect: 1.2.7(react@19.0.4)
-      use-callback-ref: 1.3.3(@types/react@19.0.7)(react@19.0.4)
-      use-sidecar: 1.1.3(@types/react@19.0.7)(react@19.0.4)
+      react: 19.0.5
+      react-clientside-effect: 1.2.7(react@19.0.5)
+      use-callback-ref: 1.3.3(@types/react@19.0.7)(react@19.0.5)
+      use-sidecar: 1.1.3(@types/react@19.0.7)(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
 
-  react-hook-form@7.54.1(react@19.0.4):
+  react-hook-form@7.54.1(react@19.0.5):
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   react-is@16.13.1: {}
 
-  react-reconciler@0.31.0-rc.0(react@19.0.4):
+  react-reconciler@0.31.0-rc.0(react@19.0.5):
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
       scheduler: 0.25.0-rc.0
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.0.7)(react@19.0.4):
+  react-remove-scroll-bar@2.3.8(@types/react@19.0.7)(react@19.0.5):
     dependencies:
-      react: 19.0.4
-      react-style-singleton: 2.2.3(@types/react@19.0.7)(react@19.0.4)
+      react: 19.0.5
+      react-style-singleton: 2.2.3(@types/react@19.0.7)(react@19.0.5)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.7
 
-  react-remove-scroll@2.6.2(@types/react@19.0.7)(react@19.0.4):
+  react-remove-scroll@2.6.2(@types/react@19.0.7)(react@19.0.5):
     dependencies:
-      react: 19.0.4
-      react-remove-scroll-bar: 2.3.8(@types/react@19.0.7)(react@19.0.4)
-      react-style-singleton: 2.2.3(@types/react@19.0.7)(react@19.0.4)
+      react: 19.0.5
+      react-remove-scroll-bar: 2.3.8(@types/react@19.0.7)(react@19.0.5)
+      react-style-singleton: 2.2.3(@types/react@19.0.7)(react@19.0.5)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.0.7)(react@19.0.4)
-      use-sidecar: 1.1.3(@types/react@19.0.7)(react@19.0.4)
+      use-callback-ref: 1.3.3(@types/react@19.0.7)(react@19.0.5)
+      use-sidecar: 1.1.3(@types/react@19.0.7)(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
 
-  react-remove-scroll@2.7.1(@types/react@19.0.7)(react@19.0.4):
+  react-remove-scroll@2.7.1(@types/react@19.0.7)(react@19.0.5):
     dependencies:
-      react: 19.0.4
-      react-remove-scroll-bar: 2.3.8(@types/react@19.0.7)(react@19.0.4)
-      react-style-singleton: 2.2.3(@types/react@19.0.7)(react@19.0.4)
+      react: 19.0.5
+      react-remove-scroll-bar: 2.3.8(@types/react@19.0.7)(react@19.0.5)
+      react-style-singleton: 2.2.3(@types/react@19.0.7)(react@19.0.5)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.0.7)(react@19.0.4)
-      use-sidecar: 1.1.3(@types/react@19.0.7)(react@19.0.4)
+      use-callback-ref: 1.3.3(@types/react@19.0.7)(react@19.0.5)
+      use-sidecar: 1.1.3(@types/react@19.0.7)(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
 
-  react-style-singleton@2.2.3(@types/react@19.0.7)(react@19.0.4):
+  react-style-singleton@2.2.3(@types/react@19.0.7)(react@19.0.5):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.0.4
+      react: 19.0.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.7
 
-  react-toastify@10.0.5(react-dom@19.0.4(react@19.0.4))(react@19.0.4):
+  react-toastify@10.0.5(react-dom@19.0.5(react@19.0.5))(react@19.0.5):
     dependencies:
       clsx: 2.1.1
-      react: 19.0.4
-      react-dom: 19.0.4(react@19.0.4)
+      react: 19.0.5
+      react-dom: 19.0.5(react@19.0.5)
 
-  react@19.0.4: {}
+  react@19.0.5: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -14902,10 +14909,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.26.7)(react@19.0.4):
+  styled-jsx@5.1.6(@babel/core@7.26.7)(react@19.0.5):
     dependencies:
       client-only: 0.0.1
-      react: 19.0.4
+      react: 19.0.5
     optionalDependencies:
       '@babel/core': 7.26.7
 
@@ -14921,9 +14928,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  suspend-react@0.1.3(react@19.0.4):
+  suspend-react@0.1.3(react@19.0.5):
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
 
   symbol-tree@3.2.4: {}
 
@@ -15071,9 +15078,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tunnel-rat@0.1.2(@types/react@19.0.7)(react@19.0.4):
+  tunnel-rat@0.1.2(@types/react@19.0.7)(react@19.0.5):
     dependencies:
-      zustand: 4.5.6(@types/react@19.0.7)(react@19.0.4)
+      zustand: 4.5.6(@types/react@19.0.7)(react@19.0.5)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -15201,39 +15208,39 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-callback-ref@1.3.3(@types/react@19.0.7)(react@19.0.4):
+  use-callback-ref@1.3.3(@types/react@19.0.7)(react@19.0.5):
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.7
 
-  use-intl@3.26.3(react@19.0.4):
+  use-intl@3.26.3(react@19.0.5):
     dependencies:
       '@formatjs/fast-memoize': 2.2.6
       intl-messageformat: 10.7.14
-      react: 19.0.4
+      react: 19.0.5
 
-  use-sidecar@1.1.3(@types/react@19.0.7)(react@19.0.4):
+  use-sidecar@1.1.3(@types/react@19.0.7)(react@19.0.5):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.0.4
+      react: 19.0.5
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.0.7
 
-  use-sync-external-store@1.2.0(react@19.0.4):
+  use-sync-external-store@1.2.0(react@19.0.5):
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
 
-  use-sync-external-store@1.4.0(react@19.0.4):
+  use-sync-external-store@1.4.0(react@19.0.5):
     dependencies:
-      react: 19.0.4
+      react: 19.0.5
 
-  usehooks-ts@3.1.1(react@19.0.4):
+  usehooks-ts@3.1.1(react@19.0.5):
     dependencies:
       lodash.debounce: 4.0.8
-      react: 19.0.4
+      react: 19.0.5
 
   utf-8-validate@5.0.10:
     dependencies:
@@ -15257,14 +15264,14 @@ snapshots:
 
   v8n@1.5.1: {}
 
-  valtio@1.13.2(@types/react@19.0.7)(react@19.0.4):
+  valtio@1.13.2(@types/react@19.0.7)(react@19.0.5):
     dependencies:
-      derive-valtio: 0.1.0(valtio@1.13.2(@types/react@19.0.7)(react@19.0.4))
+      derive-valtio: 0.1.0(valtio@1.13.2(@types/react@19.0.7)(react@19.0.5))
       proxy-compare: 2.6.0
-      use-sync-external-store: 1.2.0(react@19.0.4)
+      use-sync-external-store: 1.2.0(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
 
   viem@2.23.2(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1):
     dependencies:
@@ -15338,13 +15345,13 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1):
+  wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1):
     dependencies:
-      '@tanstack/react-query': 5.60.6(react@19.0.4)
-      '@wagmi/connectors': 5.11.2(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)))(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.4))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.4)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))(zod@3.24.1)
-      '@wagmi/core': 2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.4)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.4))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
-      react: 19.0.4
-      use-sync-external-store: 1.4.0(react@19.0.4)
+      '@tanstack/react-query': 5.60.6(react@19.0.5)
+      '@wagmi/connectors': 5.11.2(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(@wagmi/core@2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)))(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(wagmi@2.17.5(@tanstack/query-core@5.60.6)(@tanstack/react-query@5.60.6(react@19.0.5))(@types/react@19.0.7)(bufferutil@4.0.9)(react@19.0.5)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))(zod@3.24.1))(zod@3.24.1)
+      '@wagmi/core': 2.21.2(@tanstack/query-core@5.60.6)(@types/react@19.0.7)(react@19.0.5)(typescript@5.7.3)(use-sync-external-store@1.4.0(react@19.0.5))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1))
+      react: 19.0.5
+      use-sync-external-store: 1.4.0(react@19.0.5)
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)(zod@3.24.1)
     optionalDependencies:
       typescript: 5.7.3
@@ -15564,25 +15571,25 @@ snapshots:
 
   zod@4.1.11: {}
 
-  zustand@3.7.2(react@19.0.4):
+  zustand@3.7.2(react@19.0.5):
     optionalDependencies:
-      react: 19.0.4
+      react: 19.0.5
 
-  zustand@4.5.6(@types/react@19.0.7)(react@19.0.4):
+  zustand@4.5.6(@types/react@19.0.7)(react@19.0.5):
     dependencies:
-      use-sync-external-store: 1.4.0(react@19.0.4)
+      use-sync-external-store: 1.4.0(react@19.0.5)
     optionalDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
+      react: 19.0.5
 
-  zustand@5.0.0(@types/react@19.0.7)(react@19.0.4)(use-sync-external-store@1.4.0(react@19.0.4)):
+  zustand@5.0.0(@types/react@19.0.7)(react@19.0.5)(use-sync-external-store@1.4.0(react@19.0.5)):
     optionalDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
-      use-sync-external-store: 1.4.0(react@19.0.4)
+      react: 19.0.5
+      use-sync-external-store: 1.4.0(react@19.0.5)
 
-  zustand@5.0.3(@types/react@19.0.7)(react@19.0.4)(use-sync-external-store@1.4.0(react@19.0.4)):
+  zustand@5.0.3(@types/react@19.0.7)(react@19.0.5)(use-sync-external-store@1.4.0(react@19.0.5)):
     optionalDependencies:
       '@types/react': 19.0.7
-      react: 19.0.4
-      use-sync-external-store: 1.4.0(react@19.0.4)
+      react: 19.0.5
+      use-sync-external-store: 1.4.0(react@19.0.5)


### PR DESCRIPTION
## Summary

Patches **[CVE-2026-23869](https://nvd.nist.gov/vuln/detail/CVE-2026-23869)** — a high-severity (CVSS 7.5) denial of service in React Server Components reachable via App Router server action endpoints.

A specially crafted `Next-Action` POST request can trigger excessive CPU usage during deserialization, blocking the server. This repo currently uses RSC server actions in multiple places (`src/actions/*`, App Router pages), so it is in scope.

## Reporter

Reported via the **Kraken bug bounty channel** by **sky.gul** on **2026-05-08** against `inkonchain.com`. Reproduction steps included a single safe-payload demonstration request.

## What changed

- `next`: `15.4.11` → `15.5.15`
- `react`: `19.0.4` → `19.0.5`
- `react-dom`: `19.0.4` → `19.0.5`
- `pnpm.overrides` updated to match
- `pnpm-lock.yaml` regenerated (large diff is expected — Next minor bump ripples through transitive resolutions)
- `SECURITY.md`: added a `Disclosed Advisories` section documenting this CVE and the resolution

## Affected vs patched

| Package | Affected | Patched |
| --- | --- | --- |
| `next` | `>=13.0.0 <15.5.15`, `>=16.0 <16.2.3` | `15.5.15`, `16.2.3` |
| `react-server-dom-{webpack,turbopack,parcel}` | `19.0.0–19.0.4`, `19.1.0–19.1.5`, `19.2.0–19.2.4` | `19.0.5`, `19.1.6`, `19.2.5` |

## References

- Next.js advisory: https://github.com/vercel/next.js/security/advisories/GHSA-q4gf-8mx6-v5v3
- React advisory: https://github.com/facebook/react/security/advisories/GHSA-479c-33wc-g2pg
- Vercel summary: https://vercel.com/changelog/summary-of-cve-2026-23869

## Verification

- [x] `pnpm install` regenerated `pnpm-lock.yaml`; no affected `react-server-dom-*` or `react@19.0.4` resolutions remain (verified with ripgrep against the lock).
- [x] `pnpm run lint` passes locally (with placeholder env).
- [x] `pnpm exec next build` passes locally — all 20 routes build, server actions and API routes intact, only pre-existing optional-peer-dep warnings from `@metamask/sdk` (unrelated).
- [ ] CI `pr_checks` (lint / format / build on Linux against `--frozen-lockfile`) — see Actions tab on this PR.

## Review trail / merge plan

This is being merged via **self-PR + self-merge** because the Foundation is single-maintainer on this repo. Justification:

- `main` has no branch protection (verified via `gh api repos/inkfoundation/ink-web-app/branches/main/protection` → 404), so a PR is not required by repo policy. Going through a PR anyway to:
  1. trigger `pr_checks.yml` (which doesn't run on direct push to `main`),
  2. produce a structured GitHub PR record for the bounty audit.
- Will squash-merge after `pr_checks` is green.

## Post-merge

- `ship.yml` will publish a new Docker image to `ghcr.io/inkfoundation/ink-web-app` on push to `main`.
- `securesdlc.yml` (Nautilus / Semgrep) will run on `main`.
- A separate `make release` step is required to tag a date-stamped release and trigger the EKS deploy that ships the patch to `inkonchain.com`. Holding that step for explicit go-ahead so the deploy is intentional.
- After deploy, will reply to sky.gul with the commit SHA, this PR, and the release tag for retest.

## Follow-ups (out of scope here)

- `next.config.ts` currently sets `experimental.serverActions.allowedOrigins: [*]`. Not the CVE, but overly permissive — worth tightening to production hostnames in a follow-up.
- `eslint-config-next@15.0.3` and `@next/third-parties@15.1.6` lag behind `next@15.5.15`; align in a separate PR.
- `CODEOWNERS` references `@inkonchain/developers-secret` but the repo lives under `@inkfoundation` — clean up post-migration.