### PR TITLE
chore: make sentry dsn optional for vercel deploy

### DIFF
--- a/src/env-client.ts
+++ b/src/env-client.ts
@@ -6,7 +6,7 @@ export const clientEnv = createEnv({
     NEXT_PUBLIC_ENVIRONMENT: z
       .enum(["local", "development", "ci", "production"])
       .default("local"),
-    NEXT_PUBLIC_SENTRY_DSN: z.string().min(1),
+    NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
     NEXT_PUBLIC_GTM_ID: z.string().min(1),
     NEXT_PUBLIC_SEGMENT_WRITE_KEY: z.string().min(1),
     NEXT_PUBLIC_ONE_TRUST_ID: z.string().min(1),

--- a/src/sentry/sentry.client.config.ts
+++ b/src/sentry/sentry.client.config.ts
@@ -26,7 +26,9 @@ const integrations = [
 Consent.on(ConsentType.CONSENT, () => {
   Sentry.init({
     dsn: clientEnv.NEXT_PUBLIC_SENTRY_DSN,
-    enabled: clientEnv.NEXT_PUBLIC_ENVIRONMENT !== "ci",
+    enabled:
+      Boolean(clientEnv.NEXT_PUBLIC_SENTRY_DSN) &&
+      clientEnv.NEXT_PUBLIC_ENVIRONMENT !== "ci",
 
     // Adjust this value in production, or use tracesSampler for greater control
     tracesSampleRate: 0.05,

--- a/src/sentry/sentry.edge.config.ts
+++ b/src/sentry/sentry.edge.config.ts
@@ -9,7 +9,9 @@ import { clientEnv } from "../env-client";
 
 Sentry.init({
   dsn: clientEnv.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: clientEnv.NEXT_PUBLIC_ENVIRONMENT !== "ci",
+  enabled:
+    Boolean(clientEnv.NEXT_PUBLIC_SENTRY_DSN) &&
+    clientEnv.NEXT_PUBLIC_ENVIRONMENT !== "ci",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0.05,

--- a/src/sentry/sentry.server.config.ts
+++ b/src/sentry/sentry.server.config.ts
@@ -8,7 +8,9 @@ import { clientEnv } from "../env-client";
 
 Sentry.init({
   dsn: clientEnv.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: clientEnv.NEXT_PUBLIC_ENVIRONMENT !== "ci",
+  enabled:
+    Boolean(clientEnv.NEXT_PUBLIC_SENTRY_DSN) &&
+    clientEnv.NEXT_PUBLIC_ENVIRONMENT !== "ci",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0.05,


### PR DESCRIPTION
Our Sentry lives in Kraken's org (`payward-inc`), and the foundation-owned account isn't set up yet. Today `NEXT_PUBLIC_SENTRY_DSN` is a required env var, so a missing DSN fails env validation at build - which blocks deploying to Vercel without Sentry.

This makes the DSN optional and gates each `Sentry.init` on it, so with no DSN Sentry stays cleanly disabled (no init, no "missing dsn" warnings) and initializes as normal once one's provided. We can revert once we have our own Sentry setup.